### PR TITLE
Nicknames for I/O Params

### DIFF
--- a/ClipLines.cs
+++ b/ClipLines.cs
@@ -74,15 +74,15 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Lines", "", "", GH_ParamAccess.list);
-            pManager.AddRectangleParameter("Rectangle", "", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("Lines", "L", "", GH_ParamAccess.list);
+            pManager.AddRectangleParameter("Rectangle", "R", "", GH_ParamAccess.item);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Result", "", "Result", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Result", "r", "Result", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)

--- a/ClipShapes.cs
+++ b/ClipShapes.cs
@@ -74,8 +74,8 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Polylines", "", "", GH_ParamAccess.list);
-            pManager.AddRectangleParameter("Rectangle", "", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("Polylines", "P", "", GH_ParamAccess.list);
+            pManager.AddRectangleParameter("Rectangle", "R", "", GH_ParamAccess.item);
             //pManager.AddBooleanParameter("Convex", "", "", GH_ParamAccess.item, false);
 
             pManager[0].Optional = true;
@@ -84,7 +84,7 @@ namespace ClipperTwo
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Result", "", "Result", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Result", "r", "Result", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)

--- a/ClipperInters.cs
+++ b/ClipperInters.cs
@@ -90,9 +90,9 @@ namespace ClipperTwo
         }
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("PolylineA", "", "", GH_ParamAccess.item);
-            pManager.AddCurveParameter("PolylineB", "", "", GH_ParamAccess.item);
-            pManager.AddIntegerParameter("Operation", "", "", GH_ParamAccess.item, 0);
+            pManager.AddCurveParameter("PolylineA", "A", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("PolylineB", "B", "", GH_ParamAccess.item);
+            pManager.AddIntegerParameter("Operation", "O", "", GH_ParamAccess.item, 0);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
 
@@ -106,7 +106,7 @@ namespace ClipperTwo
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Result", "", "Result", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Result", "r", "Result", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)

--- a/ClipperOffset.cs
+++ b/ClipperOffset.cs
@@ -267,11 +267,11 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Polylines", "", "", GH_ParamAccess.list);
-            pManager.AddNumberParameter("Distance", "", "", GH_ParamAccess.item, 0.0);
-            pManager.AddIntegerParameter("JoinType", "", "", GH_ParamAccess.item, 0);
-            pManager.AddIntegerParameter("EndType", "", "", GH_ParamAccess.item, 0);
-            pManager.AddNumberParameter("MiterLimit", "", "", GH_ParamAccess.item, 2);
+            pManager.AddCurveParameter("Polylines", "P", "", GH_ParamAccess.list);
+            pManager.AddNumberParameter("Distance", "D", "", GH_ParamAccess.item, 0.0);
+            pManager.AddIntegerParameter("JoinType", "JT", "", GH_ParamAccess.item, 0);
+            pManager.AddIntegerParameter("EndType", "ET", "", GH_ParamAccess.item, 0);
+            pManager.AddNumberParameter("MiterLimit", "L", "", GH_ParamAccess.item, 2);
 
             pManager[0].Optional = true;
             pManager[1].Optional = true;
@@ -294,8 +294,8 @@ namespace ClipperTwo
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Holes", "", "Holes bounds", GH_ParamAccess.list);
-            pManager.AddGenericParameter("Outer", "", "Outer bounds", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Holes", "H", "Holes bounds", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Outer", "O", "Outer bounds", GH_ParamAccess.list);
         }
 
         PathsD pp = new PathsD();

--- a/ClipperUnion.cs
+++ b/ClipperUnion.cs
@@ -78,8 +78,8 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Polylines", "", "", GH_ParamAccess.list);
-            pManager.AddIntegerParameter("Union Rule", "", "", GH_ParamAccess.item, 0);
+            pManager.AddCurveParameter("Polylines", "P", "", GH_ParamAccess.list);
+            pManager.AddIntegerParameter("Union Rule", "R", "", GH_ParamAccess.item, 0);
             pManager[0].Optional = true;
             if (!(pManager[1] is Param_Integer paramInteger1))
                 return;
@@ -92,7 +92,7 @@ namespace ClipperTwo
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Result", "", "Result", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Result", "r", "Result", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)

--- a/MinkowskiSum.cs
+++ b/MinkowskiSum.cs
@@ -74,10 +74,10 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Pattern", "", "", GH_ParamAccess.item);
-            pManager.AddCurveParameter("Path", "", "", GH_ParamAccess.item);
-            pManager.AddPlaneParameter("Plane", "", "", GH_ParamAccess.item);
-            pManager.AddBooleanParameter("IsClosed", "", "", GH_ParamAccess.item, true);
+            pManager.AddCurveParameter("Pattern", "A", "", GH_ParamAccess.item);
+            pManager.AddCurveParameter("Path", "B", "", GH_ParamAccess.item);
+            pManager.AddPlaneParameter("Plane", "Pln", "", GH_ParamAccess.item);
+            pManager.AddBooleanParameter("IsClosed", "C", "", GH_ParamAccess.item, true);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
             pManager[2].Optional = true;
@@ -85,7 +85,7 @@ namespace ClipperTwo
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddGenericParameter("Result", "", "", GH_ParamAccess.list);
+            pManager.AddGenericParameter("Result", "r", "", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)

--- a/PointPlace.cs
+++ b/PointPlace.cs
@@ -75,17 +75,17 @@ namespace ClipperTwo
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
-            pManager.AddCurveParameter("Polyline", "", "", GH_ParamAccess.item);
-            pManager.AddPointParameter("Points", "", "", GH_ParamAccess.list);
+            pManager.AddCurveParameter("Polyline", "P", "", GH_ParamAccess.item);
+            pManager.AddPointParameter("Points", "Pt", "", GH_ParamAccess.list);
             pManager[0].Optional = true;
             pManager[1].Optional = true;
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
         {
-            pManager.AddPointParameter("On", "", "", GH_ParamAccess.list);
-            pManager.AddPointParameter("Inside", "", "", GH_ParamAccess.list);
-            pManager.AddPointParameter("Outside", "", "", GH_ParamAccess.list);
+            pManager.AddPointParameter("On", "X", "", GH_ParamAccess.list);
+            pManager.AddPointParameter("Inside", "In", "", GH_ParamAccess.list);
+            pManager.AddPointParameter("Outside", "Out", "", GH_ParamAccess.list);
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)


### PR DESCRIPTION
There is no reason to always show the full name, especially if the user is familiar with the component, showing the full name takes up canvas space.